### PR TITLE
Support application/json; charset=utf-8

### DIFF
--- a/src/sphinxcontrib/httpexample/parsers.py
+++ b/src/sphinxcontrib/httpexample/parsers.py
@@ -58,7 +58,7 @@ class HTTPRequest(BaseHTTPRequestHandler):
     def data(self):
         payload_bytes = self.rfile.read()
         if payload_bytes:
-            if self.headers.get('Content-Type') == 'application/json':
+            if self.headers.get('Content-Type').startswith('application/json'):
                 assert isinstance(payload_bytes, bytes)
                 payload_str = payload_bytes.decode('utf-8')
                 return ordered(json.loads(payload_str))


### PR DESCRIPTION
Support `Content-Type: application/json; charset=utf-8` in addition to `Content-Type: application/json`.

Fixes https://github.com/collective/sphinxcontrib-httpexample/pull/9