### PR TITLE
Quote the URL if it contains `&` characters in curl/httpie/wget examples

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -88,6 +88,8 @@ in pythonPackages.buildPythonPackage rec {
     rst2pdf
     check-manifest
     coveralls
+    pythonPackages.pytest
+    pythonPackages.pytestrunner
     pythonPackages.coverage
     pythonPackages.sphinx_rtd_theme
     pythonPackages.sphinx-testing

--- a/src/sphinxcontrib/httpexample/builders.py
+++ b/src/sphinxcontrib/httpexample/builders.py
@@ -2,6 +2,7 @@
 import ast
 import astunparse
 import json
+import shlex
 
 from sphinxcontrib.httpexample.utils import maybe_str
 
@@ -26,7 +27,7 @@ def build_curl_command(request):
         parts.append('-X {}'.format(request.command))
 
     # URL
-    parts.append(request.url())
+    parts.append(shlex.quote(request.url()))
 
     # Authorization (prepare)
     method, token = request.auth()
@@ -62,7 +63,7 @@ def build_wget_command(request):
         parts.append('--method={}'.format(request.command))
 
     # URL
-    parts.append(request.url())
+    parts.append(shlex.quote(request.url()))
 
     # Authorization (prepare)
     method, token = request.auth()
@@ -104,7 +105,7 @@ def build_httpie_command(request):
         parts.append(request.command)
 
     # URL
-    parts.append(request.url())
+    parts.append(shlex.quote(request.url()))
 
     # Authorization (prepare)
     method, token = request.auth()

--- a/src/sphinxcontrib/httpexample/builders.py
+++ b/src/sphinxcontrib/httpexample/builders.py
@@ -2,9 +2,13 @@
 import ast
 import astunparse
 import json
-import shlex
 
 from sphinxcontrib.httpexample.utils import maybe_str
+
+try:
+    from shlex import quote as shlex_quote
+except ImportError:
+    from pipes import quote as shlex_quote
 
 EXCLUDE_HEADERS = [
     'Authorization',
@@ -27,7 +31,7 @@ def build_curl_command(request):
         parts.append('-X {}'.format(request.command))
 
     # URL
-    parts.append(shlex.quote(request.url()))
+    parts.append(shlex_quote(request.url()))
 
     # Authorization (prepare)
     method, token = request.auth()
@@ -63,7 +67,7 @@ def build_wget_command(request):
         parts.append('--method={}'.format(request.command))
 
     # URL
-    parts.append(shlex.quote(request.url()))
+    parts.append(shlex_quote(request.url()))
 
     # Authorization (prepare)
     method, token = request.auth()
@@ -105,7 +109,7 @@ def build_httpie_command(request):
         parts.append(request.command)
 
     # URL
-    parts.append(shlex.quote(request.url()))
+    parts.append(shlex_quote(request.url()))
 
     # Authorization (prepare)
     method, token = request.auth()

--- a/tests/fixtures/007.curl.txt
+++ b/tests/fixtures/007.curl.txt
@@ -1,0 +1,1 @@
+curl -i 'http://localhost:8080/Plone/front-page?foo=bar&bar=foo' -H "Accept: application/json" --user admin:admin

--- a/tests/fixtures/007.httpie.txt
+++ b/tests/fixtures/007.httpie.txt
@@ -1,0 +1,1 @@
+http -j 'http://localhost:8080/Plone/front-page?foo=bar&bar=foo' -a admin:admin

--- a/tests/fixtures/007.python-requests.txt
+++ b/tests/fixtures/007.python-requests.txt
@@ -1,0 +1,1 @@
+requests.get('http://localhost:8080/Plone/front-page?foo=bar&bar=foo', headers={'Accept': 'application/json'}, auth=('admin', 'admin'))

--- a/tests/fixtures/007.request.txt
+++ b/tests/fixtures/007.request.txt
@@ -1,0 +1,4 @@
+GET /Plone/front-page?foo=bar&bar=foo HTTP/1.1
+Host: localhost:8080
+Accept: application/json
+Authorization: Basic YWRtaW46YWRtaW4=

--- a/tests/fixtures/007.response.txt
+++ b/tests/fixtures/007.response.txt
@@ -1,0 +1,40 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "@id": "http://localhost:8080/Plone/front-page",
+  "@type": "Document",
+  "UID": "1f699ffa110e45afb1ba502f75f7ec33",
+  "allow_discussion": null,
+  "changeNote": "",
+  "contributors": [],
+  "created": "2016-01-21T01:14:48+00:00",
+  "creators": [
+    "test_user_1_",
+    "admin"
+  ],
+  "description": "Congratulations! You have successfully installed Plone.",
+  "effective": null,
+  "exclude_from_nav": false,
+  "expires": null,
+  "id": "front-page",
+  "language": "",
+  "modified": "2016-01-21T01:24:11+00:00",
+  "parent": {
+    "@id": "http://localhost:8080/Plone",
+    "@type": "Plone Site",
+    "description": "",
+    "title": "Plone site"
+  },
+  "relatedItems": [],
+  "review_state": "private",
+  "rights": "",
+  "subjects": [],
+  "table_of_contents": null,
+  "text": {
+    "content-type": "text/plain",
+    "data": "If you're seeing this instead of the web site you were expecting, the owner of this web site has just installed Plone. Do not contact the Plone Team or the Plone mailing lists about this.",
+    "encoding": "utf-8"
+  },
+  "title": "Welcome to Plone"
+}

--- a/tests/fixtures/007.wget.txt
+++ b/tests/fixtures/007.wget.txt
@@ -1,0 +1,1 @@
+wget -S -O- 'http://localhost:8080/Plone/front-page?foo=bar&bar=foo' --header="Accept: application/json" --auth-no-challenge --user=admin --password=admin

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -41,6 +41,12 @@ from .test_fixtures import FIXTURE_006_WGET
 from .test_fixtures import FIXTURE_006_HTTPIE
 from .test_fixtures import FIXTURE_006_PYTHON_REQUESTS
 
+from .test_fixtures import FIXTURE_007_REQUEST
+from .test_fixtures import FIXTURE_007_CURL
+from .test_fixtures import FIXTURE_007_WGET
+from .test_fixtures import FIXTURE_007_HTTPIE
+from .test_fixtures import FIXTURE_007_PYTHON_REQUESTS
+
 
 def test_curl_fixture_001():
     request = parse_request(FIXTURE_001_REQUEST)
@@ -184,3 +190,27 @@ def test_requests_fixture_006():
     request = parse_request(FIXTURE_006_REQUEST)
     command = build_requests_command(request)
     assert command == FIXTURE_006_PYTHON_REQUESTS.decode('utf-8')
+
+
+def test_curl_fixture_007():
+    request = parse_request(FIXTURE_007_REQUEST)
+    command = build_curl_command(request)
+    assert command == FIXTURE_007_CURL.decode('utf-8')
+
+
+def test_wget_fixture_007():
+    request = parse_request(FIXTURE_007_REQUEST)
+    command = build_wget_command(request)
+    assert command == FIXTURE_007_WGET.decode('utf-8')
+
+
+def test_httpie_fixture_007():
+    request = parse_request(FIXTURE_007_REQUEST)
+    command = build_httpie_command(request)
+    assert command == FIXTURE_007_HTTPIE.decode('utf-8')
+
+
+def test_requests_fixture_007():
+    request = parse_request(FIXTURE_007_REQUEST)
+    command = build_requests_command(request)
+    assert command == FIXTURE_007_PYTHON_REQUESTS.decode('utf-8')

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -49,6 +49,13 @@ FIXTURE_006_HTTPIE = read_fixture('006.httpie.txt')
 FIXTURE_006_PYTHON_REQUESTS = read_fixture('006.python-requests.txt')
 FIXTURE_006_RESPONSE = read_fixture('006.response.txt')
 
+FIXTURE_007_REQUEST = read_fixture('007.request.txt')
+FIXTURE_007_CURL = read_fixture('007.curl.txt')
+FIXTURE_007_WGET = read_fixture('007.wget.txt')
+FIXTURE_007_HTTPIE = read_fixture('007.httpie.txt')
+FIXTURE_007_PYTHON_REQUESTS = read_fixture('007.python-requests.txt')
+FIXTURE_007_RESPONSE = read_fixture('007.response.txt')
+
 
 def test_fixtures():
     assert isinstance(FIXTURE_001_REQUEST, bytes)


### PR DESCRIPTION
Currently, if the URL contains any query parameters (or anything else that is a special shell character) the example command won't be copy-pasteable as-is into a shell and the user must manually quote the URL to make the command runnable.

This PR adds shell quoting for the URL to accommodate the common use of of having multiple `&` separated query parameters in the URL.  The URL will be quoted only when necessary.