### PR TITLE
Allow the URL scheme (http or https) to be configured

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,17 @@ The audience for this extension are developers and technical writes documenting 
 .. _sphinxcontrib-httpdomain: https://pythonhosted.org/sphinxcontrib-httpdomain/
 .. _plone.restapi: http://plonerestapi.readthedocs.org/
 
+* Configuration:
+
+  The URL scheme, either ``http`` or ``https``, used in the generated examples
+  can be configured with the ``httpexample_scheme`` configuration variable. It
+  defaults to ``http``.
+
+  ..  code-block:: python
+
+      # conf.py
+      httpexample_scheme = 'https'
+
 * Syntax:
 
   ..  code-block:: rst

--- a/src/sphinxcontrib/httpexample/__init__.py
+++ b/src/sphinxcontrib/httpexample/__init__.py
@@ -29,5 +29,6 @@ def setup(app):
     app.add_directive_to_domain('http', 'example', HTTPExample)
     app.add_javascript(JS_FILE)
     app.add_stylesheet(CSS_FILE)
+    app.add_config_value('httpexample_scheme', 'http', 'html')
     dist = pkg_resources.get_distribution('sphinxcontrib-httpexample')
     return {'version': dist.version}

--- a/src/sphinxcontrib/httpexample/directives.py
+++ b/src/sphinxcontrib/httpexample/directives.py
@@ -34,6 +34,8 @@ class HTTPExample(CodeBlock):
     })
 
     def run(self):
+        config = self.state.document.settings.env.config
+
         # Read enabled builders; Defaults to None
         if self.arguments:
             chosen_builders = choose_builders(self.arguments)
@@ -63,7 +65,7 @@ class HTTPExample(CodeBlock):
         # Append builder responses
         for name in chosen_builders:
             raw = ('\r\n'.join(self.content)).encode('utf-8')
-            request = parsers.parse_request(raw)
+            request = parsers.parse_request(raw, config.httpexample_scheme)
             builder_, language = AVAILABLE_BUILDERS[name]
             command = builder_(request)
 

--- a/src/sphinxcontrib/httpexample/parsers.py
+++ b/src/sphinxcontrib/httpexample/parsers.py
@@ -18,9 +18,10 @@ class HTTPRequest(BaseHTTPRequestHandler):
     scheme = 'http'
 
     # noinspection PyMissingConstructor
-    def __init__(self, request_bytes):
+    def __init__(self, request_bytes, scheme):
         assert isinstance(request_bytes, bytes)
 
+        self.scheme = scheme
         self.rfile = BytesIO(request_bytes)
         self.raw_requestline = self.rfile.readline()
         self.error_code = self.error_message = None
@@ -66,5 +67,5 @@ class HTTPRequest(BaseHTTPRequestHandler):
                 return payload_bytes
 
 
-def parse_request(request_bytes):
-    return HTTPRequest(request_bytes)
+def parse_request(request_bytes, scheme='http'):
+    return HTTPRequest(request_bytes, scheme)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -32,6 +32,11 @@ def test_parse_request_url():
     assert request.url() == 'http://localhost:8080/Plone/folder'
 
 
+def test_parse_request_url_https():
+    request = parsers.parse_request(FIXTURE_002_REQUEST, 'https')
+    assert request.url() == 'https://localhost:8080/Plone/folder'
+
+
 def test_parse_request_auth():
     request = parsers.parse_request(FIXTURE_002_REQUEST)
     assert request.auth() == ('Basic', 'admin:admin')


### PR DESCRIPTION
Adds a new configuration option, ``httpexample_scheme``, which controls
the URL scheme in the generated examples. This is a global option affecting
all examples.

It defaults to ``http`` to maintain backward compatibility.

Fixes https://github.com/collective/sphinxcontrib-httpexample/issues/5