### PR TITLE
Avoid passing -j to HTTPie unless there is request data.

### DIFF
--- a/src/sphinxcontrib/httpexample/builders.py
+++ b/src/sphinxcontrib/httpexample/builders.py
@@ -102,7 +102,11 @@ def build_wget_command(request):
 
 
 def build_httpie_command(request):
-    parts = ['http', '-j']
+    parts = ['http']
+    data = maybe_str(request.data())
+
+    if data:
+        parts.append('-j')
 
     # Method
     if request.command != 'GET':
@@ -128,7 +132,6 @@ def build_httpie_command(request):
         parts.append('{}:"{}"'.format(header, request.headers[header]))
 
     # JSON or raw data
-    data = maybe_str(request.data())
     if data:
         if request.headers.get('Content-Type') == 'application/json':
             for k, v in data.items():

--- a/tests/fixtures/001.httpie.txt
+++ b/tests/fixtures/001.httpie.txt
@@ -1,1 +1,1 @@
-http -j http://localhost:8080/Plone/front-page -a admin:admin
+http http://localhost:8080/Plone/front-page -a admin:admin

--- a/tests/fixtures/004.httpie.txt
+++ b/tests/fixtures/004.httpie.txt
@@ -1,1 +1,1 @@
-http -j http://localhost:8080/Plone/front-page
+http http://localhost:8080/Plone/front-page

--- a/tests/fixtures/005.httpie.txt
+++ b/tests/fixtures/005.httpie.txt
@@ -1,1 +1,1 @@
-http -j http://localhost:8080/Plone/front-page Authorization:"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIiwiZXhwIjoxNDY0MDQyMTAzfQ.aOyvMwdcIMV6pzC0GYQ3ZMdGaHR1_W7DxT0W0ok4FxI"
+http http://localhost:8080/Plone/front-page Authorization:"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmdWxsbmFtZSI6IiIsInN1YiI6ImFkbWluIiwiZXhwIjoxNDY0MDQyMTAzfQ.aOyvMwdcIMV6pzC0GYQ3ZMdGaHR1_W7DxT0W0ok4FxI"

--- a/tests/fixtures/007.httpie.txt
+++ b/tests/fixtures/007.httpie.txt
@@ -1,1 +1,1 @@
-http -j 'http://localhost:8080/Plone/front-page?foo=bar&bar=foo' -a admin:admin
+http 'http://localhost:8080/Plone/front-page?foo=bar&bar=foo' -a admin:admin


### PR DESCRIPTION
Passing `-j` on read requests without request data may cause the request
to fail because HTTPie adds a `Content-Type: application/json` header
which may cause the server to attempt JSON decoding on the empty body.
