### PR TITLE
Add support for Inline responses

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -30,6 +30,49 @@ Result
     Accept: application/json
     Authorization: Basic YWRtaW46YWRtaW4=
 
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "http://localhost:8080/Plone/front-page",
+      "@type": "Document",
+      "UID": "1f699ffa110e45afb1ba502f75f7ec33",
+      "allow_discussion": null,
+      "changeNote": "",
+      "contributors": [],
+      "created": "2016-01-21T01:14:48+00:00",
+      "creators": [
+        "test_user_1_",
+        "admin"
+      ],
+      "description": "Congratulations! You have successfully installed Plone.",
+      "effective": null,
+      "exclude_from_nav": false,
+      "expires": null,
+      "id": "front-page",
+      "language": "",
+      "modified": "2016-01-21T01:24:11+00:00",
+      "parent": {
+        "@id": "http://localhost:8080/Plone",
+        "@type": "Plone Site",
+        "description": "",
+        "title": "Plone site"
+      },
+      "relatedItems": [],
+      "review_state": "private",
+      "rights": "",
+      "subjects": [],
+      "table_of_contents": null,
+      "text": {
+        "content-type": "text/plain",
+        "data": "If you're seeing this instead of the web site you were expecting, the owner of this web site has just installed Plone. Do not contact the Plone Team or the Plone mailing lists about this.",
+        "encoding": "utf-8"
+      },
+      "title": "Welcome to Plone"
+    }
+
+
 Example 2
 ^^^^^^^^^
 

--- a/src/sphinxcontrib/httpexample/directives.py
+++ b/src/sphinxcontrib/httpexample/directives.py
@@ -9,7 +9,6 @@ from sphinxcontrib.httpexample import utils
 
 import os
 
-
 AVAILABLE_BUILDERS = {
     'curl': (builders.build_curl_command, 'bash'),
     'wget': (builders.build_wget_command, 'bash'),
@@ -46,13 +45,45 @@ class HTTPExample(CodeBlock):
         # Enable 'http' language for http part
         self.arguments = ['http']
 
-        # Optionally, read directive content from 'request' option
+        # split the request and optional response in the content.
+        # The separator is two empty lines followed by a line starting with 'HTTP/'
+        request_content = StringList()
+        response_content = None
+        emptylines_count = 0
+        in_response = False
+        for i, line in enumerate(self.content):
+            source = self.content.source(i)
+            if in_response:
+                response_content.append(line, source)
+            else:
+                if emptylines_count >= 2 and line.startswith('HTTP/'):
+                    in_response = True
+                    response_content = StringList()
+                    response_content.append(line, source)
+                elif line == '':
+                    emptylines_count += 1
+                else:
+                    request_content.extend(
+                        StringList([''] * emptylines_count, source))
+                    request_content.append(line, source)
+
+        # Load optional external request
         cwd = os.path.dirname(self.state.document.current_source)
         if 'request' in self.options:
             request = utils.resolve_path(self.options['request'], cwd)
             with open(request) as fp:
-                self.content = StringList(
+                request_content = StringList(
                     list(map(str.rstrip, fp.readlines())), request)
+
+        # Load optional external response
+        if 'response' in self.options:
+            response = utils.resolve_path(self.options['response'], cwd)
+            with open(response) as fp:
+                response_content = StringList(
+                    list(map(str.rstrip, fp.readlines())), response)
+
+        # reset the content to just the request
+        self.content = request_content
 
         # Wrap and render main directive as 'http-example-http'
         klass = 'http-example-http'
@@ -65,12 +96,12 @@ class HTTPExample(CodeBlock):
 
         # Append builder responses
         for name in chosen_builders:
-            raw = ('\r\n'.join(self.content)).encode('utf-8')
+            raw = ('\r\n'.join(request_content)).encode('utf-8')
             request = parsers.parse_request(raw, config.httpexample_scheme)
             builder_, language = AVAILABLE_BUILDERS[name]
             command = builder_(request)
 
-            content = StringList([command], self.content.source(0))
+            content = StringList([command], request_content.source(0))
             options = self.options.copy()
             options.pop('name', None)
             options.pop('caption', None)
@@ -97,12 +128,7 @@ class HTTPExample(CodeBlock):
             result.append(container)
 
         # Append optional response
-        if 'response' in self.options:
-            response = utils.resolve_path(self.options['response'], cwd)
-            with open(response) as fp:
-                content = StringList(
-                    list(map(str.rstrip, fp.readlines())), response)
-
+        if response_content:
             options = self.options.copy()
             options.pop('name', None)
             options.pop('caption', None)
@@ -111,7 +137,7 @@ class HTTPExample(CodeBlock):
                 'code-block',
                 ['http'],
                 options,
-                content,
+                response_content,
                 self.lineno,
                 self.content_offset,
                 self.block_text,

--- a/src/sphinxcontrib/httpexample/directives.py
+++ b/src/sphinxcontrib/httpexample/directives.py
@@ -65,6 +65,7 @@ class HTTPExample(CodeBlock):
                 else:
                     request_content.extend(
                         StringList([''] * emptylines_count, source))
+                    emptylines_count = 0
                     request_content.append(line, source)
 
         # Load optional external request


### PR DESCRIPTION
External files is annoying when we generate automatically the sphinx code.
This PR add support for inline responses.
The rule to find the separation between the request and the response is 2 empty lines followed by a line starting with "HTTP/"