### PR TITLE
Curl builder fix

### DIFF
--- a/src/sphinxcontrib/httpexample/builders.py
+++ b/src/sphinxcontrib/httpexample/builders.py
@@ -50,8 +50,7 @@ def build_curl_command(request):
     parts = ['curl', '-i']
 
     # Method
-    if request.command != 'GET':
-        parts.append('-X {}'.format(request.command))
+    parts.append('-X {}'.format(request.command))
 
     # URL
     parts.append(shlex_quote(request.url()))


### PR DESCRIPTION
This way for GET calls with a json body, curl will not default to a PUT as seen in rotki/rotki#2612