### PR TITLE
Add pull request previews on Read the Docs

### DIFF
--- a/.github/workflows/rtd-pr-preview.yml
+++ b/.github/workflows/rtd-pr-preview.yml
@@ -1,0 +1,22 @@
+# .github/workflows/rtd-pr-preview.yml
+name: readthedocs/actions
+on:
+  pull_request_target:
+    types:
+      - opened
+    # Execute this action only on PRs that touch
+    # documentation files.
+    # paths:
+    #   - "docs/**"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "sphinxcontrib-httpexample"
+          single-version: "true"

--- a/.github/workflows/rtd-pr-preview.yml
+++ b/.github/workflows/rtd-pr-preview.yml
@@ -1,4 +1,5 @@
 # .github/workflows/rtd-pr-preview.yml
+# https://github.com/readthedocs/actions/blob/v1/preview/README.md
 name: readthedocs/actions
 on:
   pull_request_target:


### PR DESCRIPTION
This PR adds the feature to display a link in the description of PRs to preview builds for every pull request and push to an open PR. It takes affect to all PRs created after this PR is merged.